### PR TITLE
Remove python2 override

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ os:
 
 before_install:
   - brew update
-  # required for tbb dependency
-  - brew unlink python && brew install python2 || true
-  - brew link --overwrite python@2
+  - brew unlink python@2
 
 script:
   # test regular build


### PR DESCRIPTION
This removes a force install and linking of python2 from the travis ci setup. This seems to be no longer needed for TBB and was causing travis to fail.