### PR TITLE
remove build options (no longer supported)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,3 @@ script:
   - brew install ./tiledb.rb --HEAD
   - brew test tiledb
   - brew uninstall tiledb
-
-  # test head build without serialization
-  - brew install ./tiledb.rb --HEAD --with-no-serialization
-  - brew test tiledb
-  - brew uninstall tiledb
-

--- a/tiledb.rb
+++ b/tiledb.rb
@@ -7,10 +7,6 @@ class Tiledb < Formula
 
     head "https://github.com/TileDB-Inc/TileDB.git", :branch => "dev"
 
-    option "with-debug", "Enables building with debug information"
-    option "with-verbose", "Enables building with verbose status messages"
-    option "with-no-serialization", "Disables building with REST serialization support"
-
     depends_on "cmake" => :build
     depends_on "tbb"
     depends_on "lzlib"
@@ -28,11 +24,8 @@ class Tiledb < Formula
 	      --enable-hdfs
 	      --disable-tests
             ]
-	    args << "--enable-debug" if build.with? "debug"
-	    args << "--enable-verbose" if build.with? "verbose"
-	    args << "--enable-serialization" unless build.with? "no-serialization"
 
-            system "../bootstrap", *args
+	    system "../bootstrap", *args
 
 	    system "make"
 	    system "make", "-C", "tiledb"


### PR DESCRIPTION
x-ref https://discourse.brew.sh/t/since-homebrew-2-0-0-install-params-always-give-invalid-option/4075/4