### PR TITLE
Update TileDB to 2.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ before_install:
 
 script:
   # test regular build
-  - brew install ./tiledb.rb
-  - brew test ./tiledb.rb
-  - brew uninstall tiledb
-
-  # test head build
-  - brew install ./tiledb.rb --HEAD
-  - brew test tiledb
-  - brew uninstall tiledb
+  - travis_wait 30 brew install ./tiledb.rb
+  - travis_wait 30 brew test ./tiledb.rb
+  - travis_wait 30 brew uninstall tiledb

--- a/README.md
+++ b/README.md
@@ -6,28 +6,22 @@ Official [Homebrew](https://brew.sh/) packages for TileDB.
 
 ## Install TileDB (from stable tap)
 
-The latest stable verison of [TileDB v2.0.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.0.1)
+The latest stable verison of [TileDB v2.1.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.1.2)
 
 ```
 brew install tiledb-inc/stable/tiledb
 ```
 
-Install the lastest development version of TileDB (`dev` branch from https://github.com/TileDB-Inc/TileDB)
-
-```
-brew install tiledb-inc/stable/tiledb --HEAD
-```
-
 To see all build build options use `brew info tiledb`
 
 ```
-TileDB/homebrew-stable [release-2.0.1●] » brew info tiledb
+TileDB/homebrew-stable [release-2.1.2●] » brew info tiledb
 
-tiledb: stable 2.0.1, HEAD
+tiledb: stable 2.1.2, HEAD
 Storage management library for sparse and dense array data
 http://tiledb.io
-/usr/local/Cellar/tiledb/2.0.1 (36 files, 7.3MB) *
-  Built from source on 2018-10-26 at 09:16:22
+/usr/local/Cellar/tiledb/2.1.2 (36 files, 7.3MB) *
+  Built from source on 2020-10-27 at 09:16:22
 From: /Users/jacobbolewski/TileDB/homebrew-stable/tiledb.rb
 ==> Dependencies
 Build: cmake ✔

--- a/tiledb.rb
+++ b/tiledb.rb
@@ -1,9 +1,9 @@
 class Tiledb < Formula
     desc "Storage management library for sparse and dense array data"
     homepage "http://tiledb.com"
-    url "https://github.com/TileDB-Inc/TileDB/archive/2.1.1.tar.gz"
-    sha256 "0df697ce9ac5858c9abc3d645f0fd96903b6512b33cf09ed4fc74d0cd4d78eec"
-    version "2.1.1"
+    url "https://github.com/TileDB-Inc/TileDB/archive/2.1.2.tar.gz"
+    sha256 "bc19281ef4a4629c3ca4d69007c0296ebcfd02579fed424de3b7d38391a848a8"
+    version "2.1.2"
 
     head "https://github.com/TileDB-Inc/TileDB.git", :branch => "dev"
 

--- a/tiledb.rb
+++ b/tiledb.rb
@@ -1,51 +1,53 @@
 class Tiledb < Formula
     desc "Storage management library for sparse and dense array data"
     homepage "http://tiledb.com"
-    url "https://github.com/TileDB-Inc/TileDB/archive/2.0.1.tar.gz"
-    sha256 "7260f8a7590d2fe8fd69d5008bf1514cd75d52425ae5a00a769b5c8d48aa18ba"
-    version "2.0.1"
+    url "https://github.com/TileDB-Inc/TileDB/archive/2.1.1.tar.gz"
+    sha256 "0df697ce9ac5858c9abc3d645f0fd96903b6512b33cf09ed4fc74d0cd4d78eec"
+    version "2.1.1"
 
     head "https://github.com/TileDB-Inc/TileDB.git", :branch => "dev"
 
     depends_on "cmake" => :build
-    depends_on "tbb"
     depends_on "lzlib"
     depends_on "lz4"
     depends_on "bzip2"
     depends_on "zstd"
 
     def install
-	# Build and install TileDB
-	mkdir "build"
-	cd "build" do
-	    args = %W[
-	      --prefix=#{prefix}
+        # Build and install TileDB
+        mkdir "build"
+        cd "build" do
+            args = %W[
+              --prefix=#{prefix}
               --enable-s3
-	      --enable-hdfs
-	      --disable-tests
+              --enable-azure
+              --enable-gcs
+              --enable-hdfs
+              --enable-serialization
+              --disable-tests
             ]
 
-	    system "../bootstrap", *args
+            system "../bootstrap", *args
 
-	    system "make"
-	    system "make", "-C", "tiledb"
-	    system "make", "-C", "tiledb", "install"
-	end
+            system "make", "-j4"
+            system "make", "-j4", "-C", "tiledb"
+            system "make", "-j4", "-C", "tiledb", "install"
+        end
     end
 
     test do
         (testpath/"test_tiledb.cpp").write <<~EOS
             #include "tiledb/tiledb.h"
-	    #include "assert.h"
-	    int main() {
-	        int major = 0;
-		int minor = 0;
-		int patch = 0;
-		tiledb_version(&major,&minor,&patch);
-		return 0;
-	    }
-	EOS
-	system ENV.cc, "test_tiledb.cpp", "-L#{lib}", "-ltiledb", "-o", "test"
-	system "./test"
+            #include "assert.h"
+            int main() {
+                int major = 0;
+                int minor = 0;
+                int patch = 0;
+                tiledb_version(&major,&minor,&patch);
+                return 0;
+            }
+        EOS
+        system ENV.cc, "test_tiledb.cpp", "-L#{lib}", "-ltiledb", "-o", "test"
+        system "./test"
     end
 end

--- a/tiledb.rb
+++ b/tiledb.rb
@@ -1,38 +1,13 @@
 class Tiledb < Formula
     desc "Storage management library for sparse and dense array data"
     homepage "http://tiledb.com"
-    url "https://github.com/TileDB-Inc/TileDB/archive/2.1.2.tar.gz"
-    sha256 "bc19281ef4a4629c3ca4d69007c0296ebcfd02579fed424de3b7d38391a848a8"
+    url "https://github.com/TileDB-Inc/TileDB/releases/download/2.1.2/tiledb-macos-2.1.2-4d3be6b-full.tar.gz"
+    sha256 "bded21c297388338cfd833124af4d46ec2b1e2520305208d74a1e4331251d5d7"
     version "2.1.2"
-
-    head "https://github.com/TileDB-Inc/TileDB.git", :branch => "dev"
-
-    depends_on "cmake" => :build
-    depends_on "lzlib"
-    depends_on "lz4"
-    depends_on "bzip2"
-    depends_on "zstd"
 
     def install
         # Build and install TileDB
-        mkdir "build"
-        cd "build" do
-            args = %W[
-              --prefix=#{prefix}
-              --enable-s3
-              --enable-azure
-              --enable-gcs
-              --enable-hdfs
-              --enable-serialization
-              --disable-tests
-            ]
-
-            system "../bootstrap", *args
-
-            system "make", "-j4"
-            system "make", "-j4", "-C", "tiledb"
-            system "make", "-j4", "-C", "tiledb", "install"
-        end
+        prefix.install Dir["*"]
     end
 
     test do


### PR DESCRIPTION
Update TileDB to 2.1.2 by using the TileDB release assets.