### PR TITLE
Fixed download URL for MacOS 2.4.0

### DIFF
--- a/tiledb.rb
+++ b/tiledb.rb
@@ -1,7 +1,7 @@
 class Tiledb < Formula
     desc "Storage management library for sparse and dense array data"
     homepage "http://tiledb.com"
-    url "https://github.com/TileDB-Inc/TileDB/releases/download/2.4.0/tiledb-macos-x86_64-release-2.4-baf64e1.tar.gz"
+    url "https://github.com/TileDB-Inc/TileDB/releases/download/2.4.0/tiledb-macos-x86_64-2.4.0-baf64e1.tar.gz"
     sha256 ""
     version "2.4.0"
 


### PR DESCRIPTION
After trying to `brew` install version 2.4.0 I noticed the download URL was wrong. Fixed it here.

```
brew install tiledb-inc/stable/tiledb
Updating Homebrew...
==> Auto-updated Homebrew!
Updated Homebrew from f50b87031 to 63fff991a.
Updated 1 tap (homebrew/core).
==> Updated Formulae
Updated 1 formula.

==> Downloading https://github.com/TileDB-Inc/TileDB/releases/download/2.4.0/tiledb-macos-x86_64-release-2.4-baf64e1.tar.gz

curl: (22) The requested URL returned error: 404
Error: tiledb: Failed to download resource "tiledb"
Download failed: https://github.com/TileDB-Inc/TileDB/releases/download/2.4.0/tiledb-macos-x86_64-release-2.4-baf64e1.tar.gz
```