### PR TITLE
Jl/release 2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Official [Homebrew](https://brew.sh/) packages for TileDB.
 
 ## Install TileDB (from stable tap)
 
-The latest stable verison of [TileDB v2.4.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.4.0)
+The latest stable verison of [TileDB v2.11.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.11.0)
 
 ```
 brew install tiledb-inc/stable/tiledb
@@ -15,26 +15,15 @@ brew install tiledb-inc/stable/tiledb
 To see all build build options use `brew info tiledb`
 
 ```
-TileDB/homebrew-stable [release-2.4.0●] » brew info tiledb
+brew info tiledb
 
-tiledb: stable 2.4.0, HEAD
+==> tiledb: stable 2.11.0
 Storage management library for sparse and dense array data
-http://tiledb.io
-/usr/local/Cellar/tiledb/2.4.0 (36 files, 7.3MB) *
-  Built from source on 2020-10-27 at 09:16:22
-From: /Users/jacobbolewski/TileDB/homebrew-stable/tiledb.rb
-==> Dependencies
-Build: cmake ✔
-Required: aws-sdk-cpp ✔, tbb ✔, lzlib ✔, lz4 ✔, bzip2 ✔, zstd ✔
-==> Options
---with-debug
-	Enables building with debug information
---with-verbose
-	Enables building with verbose status messages
---with-serialization
-        Enables the building with REST serialization support
---HEAD
-	Install HEAD version
+https://tiledb.com
+/opt/homebrew/Cellar/tiledb/2.11.0 (47 files, 19.8MB) *
+  Built from source on 2022-08-16 at 11:39:27
+From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/tiledb.rb
+License: MIT
 ```
 
 To test that the install worked correctly:

--- a/tiledb.rb
+++ b/tiledb.rb
@@ -27,7 +27,6 @@ class Tiledb < Formula
   test do
     (testpath/"test_tiledb.cpp").write <<~EOS
       #include "tiledb/tiledb.h"
-      #include "assert.h"
       int main() {
           int major = 0;
           int minor = 0;
@@ -36,7 +35,7 @@ class Tiledb < Formula
           return 0;
       }
     EOS
-    system ENV.cc, "test_tiledb.cpp", "-L#{lib}", "-ltiledb", "-o", "test"
+    system ENV.cxx, "-std=c++17", "test_tiledb.cpp", "-I#{include}", "-L#{lib}", "-ltiledb", "-o", "test"
     system "./test"
   end
 end

--- a/tiledb.rb
+++ b/tiledb.rb
@@ -1,17 +1,22 @@
-# typed: false
-# frozen_string_literal: true
-
-# Storage management library for sparse and dense array data | github.com/TileDB-Inc
 class Tiledb < Formula
   desc "Storage management library for sparse and dense array data"
-  homepage "http://tiledb.com"
-  url "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.0/tiledb-macos-x86_64-2.10.0-0b54e51.tar.gz"
-  version "2.10.0"
-  sha256 "57dce8fdc8e0fa1bf3b8e48366e529ddbf4bd948459d0893d068a680f1ab8d3f"
+  homepage "https://tiledb.com"
+  url "https://github.com/TileDB-Inc/TileDB/archive/refs/tags/2.11.0.tar.gz"
+  sha256 "98f1362a1394e6302c35ea388e480ae591031f49d5ee72087ac346191b239958"
+  license "MIT"
+  depends_on "cmake" => :build
+  depends_on "lz4"
+  depends_on "zstd"
+  depends_on "catch2"
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
 
   def install
-    # Build and install TileDB
-    prefix.install Dir["*"]
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
+      system "make"
+      system "make", "install-tiledb"
+    end
   end
 
   test do

--- a/tiledb.rb
+++ b/tiledb.rb
@@ -4,19 +4,24 @@ class Tiledb < Formula
   url "https://github.com/TileDB-Inc/TileDB/archive/refs/tags/2.11.0.tar.gz"
   sha256 "98f1362a1394e6302c35ea388e480ae591031f49d5ee72087ac346191b239958"
   license "MIT"
-  depends_on "cmake" => :build
-  depends_on "lz4"
-  depends_on "zstd"
-  depends_on "catch2"
-  uses_from_macos "bzip2"
-  uses_from_macos "zlib"
+
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-macos-arm64-2.11.0-34e5dbc.tar.gz"
+    sha256 "fe7266839a39dc55560a7b0560d0ab286e67407b2549ce373adf6bd31cf6f6c3"
+  end
+
+  if OS.mac? && Hardware::CPU.intel?
+    url "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-macos-x86_64-2.11.0-34e5dbc.tar.gz"
+    sha256 "b62c27dee8599fb2756f75463aa08f6b2d1bbb5346db7df06c9f5785b8ae2df0"
+  end
+
+  if OS.linux? && Hardware::CPU.intel?
+    url "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-linux-x86_64-2.11.0-34e5dbc.tar.gz"
+    sha256 "f4179de2d6df1eea658e0f9f68c4030b50ba85c0fcd878da8590a8bef0d1c1f3"
+  end
 
   def install
-    mkdir "build" do
-      system "cmake", "..", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
-      system "make"
-      system "make", "install-tiledb"
-    end
+    prefix.install Dir["*"]
   end
 
   test do


### PR DESCRIPTION
This PR implements the platform specific retrieval of compiled artifacts for 2.11.0. Homebrew installs the various subdirectories under its own prefixes (e.g. on my mac this is /opt/homebrew/lib, /opt/homebrew/include, and /opt/homebrew/Cellar/tiledb/2.11.0/).

This recipe can be run locally with `homebrew install tiledb.rb` (Note that testing requires explicitly running `homebrew test tiledb.rb`)